### PR TITLE
Validate acceptance of CoC

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -6,10 +6,10 @@ class ApplicationsController < ApplicationController
   def create
     @application = Application.new(params.require(:application).permit(:name,
       :email, :language_de, :language_en, :attended_before, :rejected_before, :level,
-      :comments, :os, :needs_computer))
+      :comments, :os, :needs_computer, :read_coc))
+      
     unless @application.save
-      render :new 
+      render :new
     end
-
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,6 +5,7 @@ class Application < ApplicationRecord
    validates :level, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 10 }
    validates :os, presence: true, unless: :needs_computer?
    validate :at_least_select_one_language
+   validates :read_coc, acceptance: true
 
    def at_least_select_one_language
      unless language_de? || language_en?

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -18,10 +18,11 @@
 <p><%= f.label(:language_de) %> <%= f.check_box :language_de %></p>
 <p><%= f.label(:language_en) %> <%= f.check_box :language_en %></p>
 <p><%= f.label(:attended_before) %> <%= f.check_box :attended_before %></p>
-<p><%= f.label(:rejected_before)%> <%= f.check_box :rejected_before %></p>
-<p><%= f.label(:level)%> <%= f.number_field(:level, in: 0..10, step: 1) %></p>
-<p><%= f.label(:comments)%> <%= f.text_area :comments %></p>
-<p><%= f.label(:os)%> <%= f.select(:os, options_for_select([["Linux", "linux"], ["Mac", "mac"], ["Windows", "windows"]]), include_blank: true) %></p>
-<p><%= f.label(:needs_computer)%><%= f.check_box :needs_computer %></p>
+<p><%= f.label(:rejected_before) %> <%= f.check_box :rejected_before %></p>
+<p><%= f.label(:level) %> <%= f.number_field(:level, in: 0..10, step: 1) %></p>
+<p><%= f.label(:comments) %> <%= f.text_area :comments %></p>
+<p><%= f.label(:os) %> <%= f.select(:os, options_for_select([["Linux", "linux"], ["Mac", "mac"], ["Windows", "windows"]]), include_blank: true) %></p>
+<p><%= f.label(:needs_computer) %> <%= f.check_box :needs_computer %></p>
+<p><%= f.label(:read_coc) %> <%= f.check_box :read_coc %></p>
 <%= f.submit "Create" %>
 <% end %>


### PR DESCRIPTION
(this was mostly written in my computer by @juopmu)

The reason while it didn't work before is because we forgot to add it to the [list of attributes permitted to be saved in the controller](https://github.com/rubymonsters/rgbapp/pull/12/files#diff-2ecfd4e7b8df799bdedcaa53e76630e7L9) 😅 

Fixes #8.