### PR TITLE
Add layout for dates section

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,10 +22,20 @@ h1 {
   font-size: 30px;
 }
 
-h2{
+h2 {
  font-size: 16px;
-  font-style: italic;
+ font-style: italic;
 }
+
+h3 {
+  color:#c4220d;
+  font-size: 18px;
+}
+
+h3 span {
+  color:#000000;
+}
+
 body {
   margin: 30px auto;
   font-family: 'Open Sans', sans-serif;
@@ -34,10 +44,13 @@ body {
   width: 60%;
 }
 
+article aside {
+  border-top: 1px solid #777777;
+}
 
 fieldset {
-border: none;
-border-top: 1px solid #777777;
+  border: none;
+  border-top: 1px solid #777777;
 
 }
 

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -1,5 +1,6 @@
 <article>
     <h1>Rails Girls Berlin Beginners Workshop [date]</h1>
+
     <article>
         <p>Rails Girls Berlin want to give total beginners the opportunity and a community to start learning the technology to build their ideas and continue coding.</p>
         <p>The Beginners Workshop is a hands on introduction to Rails. The workshop has a main focus on women with no previous Ruby on Rails programming experience and who want to be able to build their own applications. The program of the workshop includes
@@ -14,12 +15,20 @@
 
         <p>We are looking forward to seeing you <3</p>
 
-        <p>Application Start: [date]</p>
-        <p>Application End: [date]</p>
-        <p>Confirmation Mails: [date]</p>
+        <aside>
+          <h3>
+            Application Start: <span>tba</span>
+          </h3>
+          <h3>
+            Application End: <span>tba</span>
+          </h3>
+          <h3>
+            Confirmation Mails: <span>tba</span>
+          </h3>
+        </aside>
 
-        <p>* Required</p>
-    </article>
+  </article>
+
     <%= form_for @application do |f| %>
     <% if @application.errors.any? %>
     <div id="error_explanation">
@@ -36,6 +45,8 @@
     </div>
     <% end %>
     <fieldset>
+        <p>* Required</p>
+
         <h2>Personal Information</h2>
         <p><%= f.check_box :female %>
           <%= f.label(:female, "I am a woman / non-binary person.") %>


### PR DESCRIPTION
We changed the style of the application dates section so it fits the style on the Rails Girls Berlin website. We did this before checking Katja's commit and now think her approach - putting the dates into a list - is better.