### PR TITLE
Truncate comments

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -232,6 +232,23 @@ tr:nth-child(even) {background-color: #ffe6e6}
 
 tr:hover {background-color: #ffb3b3}
 
+/* Shorten text in comment field */
+
+.shorten-long-text {
+   white-space: nowrap;
+   overflow: hidden;
+   max-width: 200px;
+   text-overflow: ellipsis;
+}
+
+.shorten-long-text:hover {
+  overflow: visible;
+  white-space: normal;
+  display: block;
+  width: 400px;
+  height: auto;
+}
+
 /* Tooltip container */
 .tooltip {
     position: relative;

--- a/app/views/applications/index.html.erb
+++ b/app/views/applications/index.html.erb
@@ -34,7 +34,7 @@
       <td><%= application.os %></td>
       <td class="center"><% if application.needs_computer %> ✅ <% end %></td>
       <td><%= application.created_at.strftime("%d.%m.%Y") %></td>
-      <td><%= application.comments %></td>
+      <td class="shorten-long-text"><%= application.comments %></td>
     </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
People seem to leave long comments, which makes the table look weird. I added css to shorten the comment text and fully display it when hovering over the shortened text.